### PR TITLE
feat: Add 'ItemList' parameter type for scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.32.1",
     "vite": "^6.3.5",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.3",
+    "@testing-library/react": "^15.0.0",
+    "@testing-library/jest-dom": "^6.4.8"
   },
   "dependencies": {
     "@mui/icons-material": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,12 @@ importers:
       '@eslint/js':
         specifier: ^9.26.0
         version: 9.26.0
+      '@testing-library/jest-dom':
+        specifier: ^6.4.8
+        version: 6.6.3
+      '@testing-library/react':
+        specifier: ^15.0.0
+        version: 15.0.7(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/node':
         specifier: ^22.15.18
         version: 22.15.18
@@ -80,6 +86,9 @@ importers:
         version: 3.1.3(@types/node@22.15.18)(jsdom@26.1.0)
 
 packages:
+
+  '@adobe/css-tools@4.4.3':
+    resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -716,6 +725,28 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@15.0.7':
+    resolution: {integrity: sha512-cg0RvEdD1TIhhkm1IeYMQxrzy0MtUNfa3minv4MjbgcYzJAZ7yD0i0lwoPOTPr+INtiXFezt2o8xMSnyHhEn2Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': ^18.0.0
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -754,6 +785,11 @@ packages:
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
 
   '@types/react-dom@19.1.5':
     resolution: {integrity: sha512-CMCjrWucUBZvohgZxkjd6S9h0nZxXjzus6yDfUb+xLxYM7VvjKNH1tQrE9GWLql1XoOP4/Ds3bwFqShHUYraGg==}
@@ -912,12 +948,23 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -981,6 +1028,10 @@ packages:
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
+
+  chalk@3.0.0:
+    resolution: {integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==}
+    engines: {node: '>=8'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1053,6 +1104,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssstyle@4.3.1:
     resolution: {integrity: sha512-ZgW+Jgdd7i52AaLYCriF8Mxqft0gD/R9i9wi6RWBhs1pqdPEzPjym7rvRKi397WmQFf3SlyUsszhw+VVCbx79Q==}
     engines: {node: '>=18'}
@@ -1105,6 +1159,12 @@ packages:
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -1454,6 +1514,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1563,6 +1627,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
@@ -1575,6 +1642,10 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -1624,6 +1695,10 @@ packages:
   mime-types@3.0.1:
     resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1754,6 +1829,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -1794,6 +1873,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-is@19.1.0:
     resolution: {integrity: sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==}
 
@@ -1810,6 +1892,10 @@ packages:
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   refractor@4.9.0:
     resolution: {integrity: sha512-nEG1SPXFoGGx+dcjftjv8cAjEusIh6ED1xhf5DG3C0x/k+rmZ2duKnc3QLpt6qeHv5fPb8uwN3VWN2BT7fr3Og==}
@@ -1942,6 +2028,10 @@ packages:
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2268,6 +2358,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.3': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -2856,6 +2948,39 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.40.1':
     optional: true
 
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.27.1
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.3
+      aria-query: 5.3.0
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+
+  '@testing-library/react@15.0.7(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@testing-library/dom': 10.4.0
+      '@types/react-dom': 18.3.7(@types/react@19.1.4)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.4
+
+  '@types/aria-query@5.0.4': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.27.1
@@ -2902,6 +3027,10 @@ snapshots:
   '@types/prismjs@1.26.5': {}
 
   '@types/prop-types@15.7.14': {}
+
+  '@types/react-dom@18.3.7(@types/react@19.1.4)':
+    dependencies:
+      '@types/react': 19.1.4
 
   '@types/react-dom@19.1.5(@types/react@19.1.4)':
     dependencies:
@@ -3114,11 +3243,19 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   assertion-error@2.0.1: {}
 
@@ -3194,6 +3331,11 @@ snapshots:
       loupe: 3.1.3
       pathval: 2.0.0
 
+  chalk@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3254,6 +3396,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssstyle@4.3.1:
     dependencies:
       '@asamuzakjp/css-color': 3.1.7
@@ -3291,6 +3435,10 @@ snapshots:
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -3738,6 +3886,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inherits@2.0.4: {}
 
   ipaddr.js@1.9.1: {}
@@ -3839,6 +3989,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.21: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
@@ -3850,6 +4002,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.17:
     dependencies:
@@ -3902,6 +4056,8 @@ snapshots:
   mime-types@3.0.1:
     dependencies:
       mime-db: 1.54.0
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -4029,6 +4185,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4068,6 +4230,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-is@19.1.0: {}
 
   react-refresh@0.17.0: {}
@@ -4082,6 +4246,11 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   refractor@4.9.0:
     dependencies:
@@ -4265,6 +4434,10 @@ snapshots:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 

--- a/src/action/Action.test.tsx
+++ b/src/action/Action.test.tsx
@@ -1,0 +1,296 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
+import OBR, { type Item } from "@owlbear-rodeo/sdk";
+import { Parameter } from "./Action"; // Assuming Parameter is exported from Action.tsx
+import { ScriptContainerUtils } from "../state/ScriptContainerUtils";
+import type { StoredScript, ParameterWithValue } from "../state/StoredScript";
+
+// Mock OBR
+vi.mock("@owlbear-rodeo/sdk", async (importOriginal) => {
+    const actual = await importOriginal<typeof OBR>();
+    return {
+        ...actual,
+        default: {
+            player: {
+                getSelection: vi.fn(),
+            },
+            scene: {
+                items: {
+                    getItems: vi.fn(),
+                },
+            },
+            notification: {
+                show: vi.fn(),
+            },
+        },
+        // Keep other exports like isImage if they are used by the component
+        isImage: actual.isImage,
+    };
+});
+
+// Mock ScriptContainerUtils
+vi.mock("../state/ScriptContainerUtils", () => ({
+    ScriptContainerUtils: {
+        setParameterValue: vi.fn(),
+    },
+    // Assuming withLocalAndRemoteContainers is used by handleSetParameterValue
+    // and it just needs to execute the callback for testing purposes.
+    withLocalAndRemoteContainers: vi.fn((callback) => callback(usePlayerStorage.getState().roomMetadata.scripts)),
+}));
+
+// Mock usePlayerStorage if needed for withLocalAndRemoteContainers or other hooks
+// This is a simplified mock. If the actual implementation relies on specific state, adjust accordingly.
+const mockPlayerStorageState = {
+    roomMetadata: {
+        scripts: new Map(), // Or some other appropriate initial value
+    },
+    // Add other state properties if the component/hooks depend on them
+};
+vi.mock("../state/usePlayerStorage", () => ({
+    usePlayerStorage: vi.fn((selector) => selector(mockPlayerStorageState)),
+}));
+
+
+describe("Parameter component with ItemList type", () => {
+    const mockScript: StoredScript = {
+        id: "test-script",
+        name: "Test Script",
+        code: "",
+        author: "Test Author",
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        parameters: [], // Will be populated by the param below
+        // Add other StoredScript properties if necessary
+    };
+
+    const baseItemListParam: Omit<ParameterWithValue, "value"> = {
+        name: "itemListParam",
+        description: "Select Multiple Items",
+        type: "ItemList",
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Reset mockPlayerStorageState if necessary for isolation between tests
+        mockPlayerStorageState.roomMetadata.scripts = new Map(); 
+    });
+
+    describe("Rendering", () => {
+        it('should display "Set Multi-Selection" when value is undefined', () => {
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: undefined } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+            expect(screen.getByText("Set Multi-Selection")).toBeInTheDocument();
+        });
+
+        it('should display "Set Multi-Selection" when value is an empty array', () => {
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: [] } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+            expect(screen.getByText("Set Multi-Selection")).toBeInTheDocument();
+        });
+
+        it('should display "1 item(s) selected" when value has one item', () => {
+            const mockItem: Item = { id: "item1", layer: "CHARACTER", name:"Item 1", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{}};
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: [mockItem] } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+            expect(screen.getByText("1 item(s) selected")).toBeInTheDocument();
+        });
+
+        it('should display "2 item(s) selected" when value has two items', () => {
+            const mockItems: Item[] = [
+                { id: "item1", layer: "CHARACTER", name:"Item 1", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{}},
+                { id: "item2", layer: "CHARACTER", name:"Item 2", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{}},
+            ];
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: mockItems } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+            expect(screen.getByText("2 item(s) selected")).toBeInTheDocument();
+        });
+    });
+
+    describe("Selection Logic", () => {
+        const mockPlayerGetSelection = OBR.player.getSelection as vi.Mock;
+        const mockSceneGetItems = OBR.scene.items.getItems as vi.Mock;
+        const mockNotificationShow = OBR.notification.show as vi.Mock;
+
+        it("should set parameter value with selected items on successful selection", async () => {
+            const selectedIds = ["item1-id", "item2-id"];
+            const selectedItems: Item[] = [
+                { id: "item1-id", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} },
+                { id: "item2-id", name: "Item 2", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} },
+            ];
+            mockPlayerGetSelection.mockResolvedValue(selectedIds);
+            mockSceneGetItems.mockResolvedValue(selectedItems);
+
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: undefined } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+
+            fireEvent.click(screen.getByText("Set Multi-Selection"));
+
+            await waitFor(() => {
+                expect(mockPlayerGetSelection).toHaveBeenCalled();
+                expect(mockSceneGetItems).toHaveBeenCalledWith(selectedIds);
+                expect(ScriptContainerUtils.setParameterValue).toHaveBeenCalledWith(
+                    mockPlayerStorageState.roomMetadata.scripts,
+                    mockScript.id,
+                    0,
+                    selectedItems,
+                );
+            });
+        });
+
+        it("should show notification and not set value if no items are selected", async () => {
+            mockPlayerGetSelection.mockResolvedValue([]);
+
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: undefined } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+
+            fireEvent.click(screen.getByText("Set Multi-Selection"));
+
+            await waitFor(() => {
+                expect(mockPlayerGetSelection).toHaveBeenCalled();
+                expect(mockNotificationShow).toHaveBeenCalledWith(
+                    "No items selected",
+                    "INFO",
+                );
+                expect(mockSceneGetItems).not.toHaveBeenCalled();
+                expect(ScriptContainerUtils.setParameterValue).not.toHaveBeenCalled();
+            });
+        });
+        
+        it("should show notification and clear value if selected items cannot be retrieved", async () => {
+            const selectedIds = ["item1-id"];
+            mockPlayerGetSelection.mockResolvedValue(selectedIds);
+            mockSceneGetItems.mockResolvedValue([]); // Items not found
+
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: [{ id: "old-item", name:"Old Item", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} }] } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+            
+            // Initial state shows "1 item(s) selected"
+            expect(screen.getByText("1 item(s) selected")).toBeInTheDocument();
+
+            fireEvent.click(screen.getByText("1 item(s) selected")); // or the chip itself
+
+            await waitFor(() => {
+                expect(mockPlayerGetSelection).toHaveBeenCalled();
+                expect(mockSceneGetItems).toHaveBeenCalledWith(selectedIds);
+                expect(mockNotificationShow).toHaveBeenCalledWith(
+                    "Could not retrieve selected items.",
+                    "WARNING",
+                );
+                expect(ScriptContainerUtils.setParameterValue).toHaveBeenCalledWith(
+                    mockPlayerStorageState.roomMetadata.scripts,
+                    mockScript.id,
+                    0,
+                    undefined, // Value should be cleared
+                );
+            });
+        });
+    });
+
+    describe("Clearing Selection", () => {
+        it("should call setParameterValue with undefined when delete is clicked", async () => {
+            const mockItem: Item = { id: "item1", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} };
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: [mockItem] } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+
+            // The delete icon is usually part of the Chip component and not directly accessible by role
+            // We target the Chip's delete handler. Material UI Chip has a specific structure.
+            // We can find the cancel icon by its role if it's standard.
+            const deleteIcon = screen.getByTestId("CancelIcon"); // MUI specific, ensure this is how it's rendered or use a more generic selector
+            fireEvent.click(deleteIcon);
+
+            await waitFor(() => {
+                expect(ScriptContainerUtils.setParameterValue).toHaveBeenCalledWith(
+                    mockPlayerStorageState.roomMetadata.scripts,
+                    mockScript.id,
+                    0,
+                    undefined,
+                );
+            });
+        });
+
+        it("should not have a delete handler if no items are selected", () => {
+            render(
+                <Parameter
+                    editingDisabled={false}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: [] } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+            // Check if the delete icon is not present
+            expect(screen.queryByTestId("CancelIcon")).not.toBeInTheDocument();
+        });
+    });
+    
+    describe("Disabled State", () => {
+        it("should disable the chip when editingDisabled is true", () => {
+            const mockItem: Item = { id: "item1", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} };
+            render(
+                <Parameter
+                    editingDisabled={true}
+                    script={mockScript}
+                    param={{ ...baseItemListParam, value: [mockItem] } as ParameterWithValue}
+                    idx={0}
+                />,
+            );
+            // The Chip component itself will have the 'Mui-disabled' class or 'disabled' attribute
+            // The exact way to check depends on how Chip is rendered and its props
+            // We can check if the underlying button/div is disabled
+            // For MUI Chip, the root element gets `Mui-disabled` class.
+            const chip = screen.getByText("1 item(s) selected").closest(".MuiChip-root");
+            expect(chip).toHaveClass("Mui-disabled");
+
+            // Try to click to ensure no action happens (though true disabled state prevents event firing)
+            fireEvent.click(chip!);
+            expect(OBR.player.getSelection as vi.Mock).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/src/action/Action.test.tsx
+++ b/src/action/Action.test.tsx
@@ -1,18 +1,28 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'; // Explicit imports, added Mock
 import OBR, { type Item } from "@owlbear-rodeo/sdk";
-import { Parameter } from "./Action"; // Assuming Parameter is exported from Action.tsx
+import type { ScriptParameter } from "../script/CodeoScript";
+import { Parameter } from "./Action";
 import { ScriptContainerUtils } from "../state/ScriptContainerUtils";
-import type { StoredScript, ParameterWithValue } from "../state/StoredScript";
+import type { StoredScript } from "../state/StoredScript";
+import { usePlayerStorage } from "../state/usePlayerStorage";
 
-// Mock OBR
+import type { PlayerStorage } from "../state/usePlayerStorage"; // For typing mocks
+import type { ScriptContainer } from "../state/ScriptContainerUtils"; // For typing mocks
+import type { WritableDraft } from "immer"; // For typing mocks
+
+// Mock OBR SDK
 vi.mock("@owlbear-rodeo/sdk", async (importOriginal) => {
-    const actual = await importOriginal<typeof OBR>();
+    type ActualSDK = typeof import("@owlbear-rodeo/sdk");
+    const actualSDK = await importOriginal<ActualSDK>();
     return {
-        ...actual,
-        default: {
+        ...actualSDK, // Spread all actual named exports (includes isImage, buildCurve, etc.)
+        default: { // Mock the default OBR object
+            // Keep existing mocks for specific OBR functionalities if needed by Parameter component indirectly
+            // For 'Parameter' component, direct OBR usage is mainly for OBR.player.getSelection, OBR.scene.items.getItems, OBR.notification.show
             player: {
                 getSelection: vi.fn(),
+                select: vi.fn(), // Added missing select mock from conceptual example
             },
             scene: {
                 items: {
@@ -22,9 +32,9 @@ vi.mock("@owlbear-rodeo/sdk", async (importOriginal) => {
             notification: {
                 show: vi.fn(),
             },
+            // Add other OBR default properties if they are accessed and need mocking
+            // For instance, if OBR.isReady or OBR.onReady are used. Based on Action.tsx, they are not directly by Parameter.
         },
-        // Keep other exports like isImage if they are used by the component
-        isImage: actual.isImage,
     };
 });
 
@@ -35,19 +45,61 @@ vi.mock("../state/ScriptContainerUtils", () => ({
     },
     // Assuming withLocalAndRemoteContainers is used by handleSetParameterValue
     // and it just needs to execute the callback for testing purposes.
-    withLocalAndRemoteContainers: vi.fn((callback) => callback(usePlayerStorage.getState().roomMetadata.scripts)),
+    withLocalAndRemoteContainers: vi.fn((callback: (draft: WritableDraft<ScriptContainer>) => void) => {
+        const state = usePlayerStorage.getState() as PlayerStorage; // Cast for safety
+        // This mock implementation of withLocalAndRemoteContainers might need to be more sophisticated
+        // if the actual callback relies on immer drafts or specific container structures.
+        // For now, we'll assume it can work with a simplified container or direct state.
+        // If ScriptContainer is just { scripts: StoredScript[] }, this could be:
+        // callback({ scripts: state.roomMetadata.scripts as unknown as StoredScript[] });
+        // However, the original mock passed state.roomMetadata.scripts, which is a Map.
+        // This part is tricky without knowing the exact expectation of the callback.
+        // Let's assume for now the callback expects a structure that can be derived from state.roomMetadata
+        // For simplicity, we'll pass a compatible structure if possible, or adjust if tests fail here.
+        // The original mock passed `state.roomMetadata.scripts` which is a Map.
+        // The `updater` in the real code expects `WritableDraft<ScriptContainer>`.
+        // This mock needs to provide something compatible with that.
+        // A simple approach:
+        const mockDraftContainer: WritableDraft<ScriptContainer> = { scripts: Array.from(state.roomMetadata.scripts.values()) };
+        return callback(mockDraftContainer);
+    }),
 }));
 
-// Mock usePlayerStorage if needed for withLocalAndRemoteContainers or other hooks
-// This is a simplified mock. If the actual implementation relies on specific state, adjust accordingly.
-const mockPlayerStorageState = {
-    roomMetadata: {
-        scripts: new Map(), // Or some other appropriate initial value
-    },
-    // Add other state properties if the component/hooks depend on them
+// Mock usePlayerStorage
+// Adjusted mockPlayerStorageState structure
+const mockPlayerStorageState: PlayerStorage = {
+    roomMetadata: { scripts: [] as StoredScript[] } as ScriptContainer,
+    scripts: [] as StoredScript[], // This is likely the store for local scripts
+    executions: new Map(),
+    role: "GM",
+    playerName: "TestPlayer",
+    // playerId: "test-player-id", // Removed as it's not in PlayerStorage type
+    // isReady: true, // Removed as it's not in PlayerStorage type
+    addLocalScript: vi.fn(),
+    getScriptById: vi.fn(),
+    // updateLocalStateContainer's updater operates on a ScriptContainer.
+    // We'll mock it to operate on an object { scripts: mockPlayerStorageState.scripts }
+    updateLocalStateContainer: vi.fn((updater) => {
+        const localScriptContainer: WritableDraft<ScriptContainer> = { scripts: mockPlayerStorageState.scripts };
+        updater(localScriptContainer);
+    }),
+    markScriptRun: vi.fn(),
+    addExecution: vi.fn(),
+    removeExecution: vi.fn(),
+    // getState is not part of PlayerStorage state object, it's part of the store itself.
+    // So, it's removed from mockPlayerStorageState.
 };
+
+// Properly mock the Zustand store pattern for usePlayerStorage
+const mockedUsePlayerStorageHook = vi.fn(<TSelected = unknown>(selector: (store: PlayerStorage) => TSelected) => {
+    return selector(mockPlayerStorageState);
+});
+const mockedGetState = () => mockPlayerStorageState;
+
 vi.mock("../state/usePlayerStorage", () => ({
-    usePlayerStorage: vi.fn((selector) => selector(mockPlayerStorageState)),
+    usePlayerStorage: Object.assign(mockedUsePlayerStorageHook, {
+        getState: mockedGetState,
+    }),
 }));
 
 
@@ -59,20 +111,36 @@ describe("Parameter component with ItemList type", () => {
         author: "Test Author",
         createdAt: Date.now(),
         updatedAt: Date.now(),
-        parameters: [], // Will be populated by the param below
-        // Add other StoredScript properties if necessary
+        runAt: Date.now(), 
+        parameters: [], 
     };
 
-    const baseItemListParam: Omit<ParameterWithValue, "value"> = {
+    // baseItemListParam now correctly uses the imported ScriptParameter type
+    const baseItemListParam: ScriptParameter = { 
         name: "itemListParam",
         description: "Select Multiple Items",
-        type: "ItemList",
+        type: "ItemList", // Set to "ItemList" directly
     };
+
+    const mockDate = new Date().toISOString();
+    const mockUserId = "test-user-id";
 
     beforeEach(() => {
         vi.clearAllMocks();
-        // Reset mockPlayerStorageState if necessary for isolation between tests
-        mockPlayerStorageState.roomMetadata.scripts = new Map(); 
+        // Reset contents of mutable parts of mockPlayerStorageState
+        if (mockPlayerStorageState.roomMetadata?.scripts) {
+            mockPlayerStorageState.roomMetadata.scripts.length = 0;
+        }
+        // Reset the local scripts array directly
+        mockPlayerStorageState.scripts.length = 0; 
+        mockPlayerStorageState.executions.clear();
+        
+        // Also reset mocks on OBR's default export methods and other vi.fn()
+        (OBR.player.getSelection as Mock).mockClear();
+        (OBR.scene.items.getItems as Mock).mockClear();
+        (OBR.notification.show as Mock).mockClear();
+        (ScriptContainerUtils.setParameterValue as Mock).mockClear();
+
     });
 
     describe("Rendering", () => {
@@ -81,7 +149,7 @@ describe("Parameter component with ItemList type", () => {
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: undefined } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: undefined }}
                     idx={0}
                 />,
             );
@@ -93,7 +161,7 @@ describe("Parameter component with ItemList type", () => {
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: [] } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: [] }}
                     idx={0}
                 />,
             );
@@ -101,12 +169,15 @@ describe("Parameter component with ItemList type", () => {
         });
 
         it('should display "1 item(s) selected" when value has one item', () => {
-            const mockItem: Item = { id: "item1", layer: "CHARACTER", name:"Item 1", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{}};
+            const mockItem: Item = { 
+                id: "item1", layer: "CHARACTER", name:"Item 1", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId, 
+            };
             render(
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: [mockItem] } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: [mockItem] }}
                     idx={0}
                 />,
             );
@@ -115,14 +186,20 @@ describe("Parameter component with ItemList type", () => {
 
         it('should display "2 item(s) selected" when value has two items', () => {
             const mockItems: Item[] = [
-                { id: "item1", layer: "CHARACTER", name:"Item 1", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{}},
-                { id: "item2", layer: "CHARACTER", name:"Item 2", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{}},
+                { 
+                    id: "item1", layer: "CHARACTER", name:"Item 1", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                    createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+                },
+                {
+                    id: "item2", layer: "CHARACTER", name:"Item 2", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                    createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+                },
             ];
             render(
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: mockItems } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: mockItems }}
                     idx={0}
                 />,
             );
@@ -131,24 +208,28 @@ describe("Parameter component with ItemList type", () => {
     });
 
     describe("Selection Logic", () => {
-        const mockPlayerGetSelection = OBR.player.getSelection as vi.Mock;
-        const mockSceneGetItems = OBR.scene.items.getItems as vi.Mock;
-        const mockNotificationShow = OBR.notification.show as vi.Mock;
-
+        // Component uses OBR.player.getSelection, so mock OBR.player.getSelection directly
+        // The mock structure for default export handles this.
+        // We cast OBR.player.getSelection to Mock (imported from vitest) when setting up mock behavior for a test.
         it("should set parameter value with selected items on successful selection", async () => {
-            const selectedIds = ["item1-id", "item2-id"];
-            const selectedItems: Item[] = [
-                { id: "item1-id", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} },
-                { id: "item2-id", name: "Item 2", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} },
-            ];
-            mockPlayerGetSelection.mockResolvedValue(selectedIds);
-            mockSceneGetItems.mockResolvedValue(selectedItems);
+            (OBR.player.getSelection as Mock).mockResolvedValue(["item1-id", "item2-id"]);
+            (OBR.scene.items.getItems as Mock).mockResolvedValue([
+                { 
+                    id: "item1-id", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                    createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+                },
+                { 
+                    id: "item2-id", name: "Item 2", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                    createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+                },
+            ]);
+            // Removed unused selectedIds and selectedItems variables
 
             render(
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: undefined } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: undefined }}
                     idx={0}
                 />,
             );
@@ -156,25 +237,45 @@ describe("Parameter component with ItemList type", () => {
             fireEvent.click(screen.getByText("Set Multi-Selection"));
 
             await waitFor(() => {
-                expect(mockPlayerGetSelection).toHaveBeenCalled();
-                expect(mockSceneGetItems).toHaveBeenCalledWith(selectedIds);
+                expect(OBR.player.getSelection).toHaveBeenCalled();
+                expect(OBR.scene.items.getItems).toHaveBeenCalledWith(["item1-id", "item2-id"]);
                 expect(ScriptContainerUtils.setParameterValue).toHaveBeenCalledWith(
-                    mockPlayerStorageState.roomMetadata.scripts,
+                    // The mock for withLocalAndRemoteContainers passes a ScriptContainer draft
+                    // The assertion here should match what that draft would look like.
+                    // If it's { scripts: Array.from(state.roomMetadata.scripts.values()) }
+                    // then this check needs to be consistent.
+                    // For now, assuming the mockPlayerStorageState.roomMetadata.scripts (Map) was intended,
+                    // but this is likely where the `unbound-method` or `no-unsafe-call` could stem from if types mismatch.
+                    // Let's assume the actual check is on the content:
+                    // The first argument to setParameterValue is the container.
+                    // In the mocked withLocalAndRemoteContainers, we pass mockDraftContainer.
+                    // So, we expect that specific structure (or a matcher for it).
+                    mockPlayerStorageState.roomMetadata, // This should now be {scripts: []}
                     mockScript.id,
                     0,
-                    selectedItems,
+                    // The actual items from the getItems mock
+                    [ 
+                        { 
+                            id: "item1-id", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                            createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+                        },
+                        { 
+                            id: "item2-id", name: "Item 2", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                            createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+                        },
+                    ]
                 );
             });
         });
 
         it("should show notification and not set value if no items are selected", async () => {
-            mockPlayerGetSelection.mockResolvedValue([]);
+            (OBR.player.getSelection as Mock).mockResolvedValue([]);
 
             render(
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: undefined } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: undefined }}
                     idx={0}
                 />,
             );
@@ -182,44 +283,39 @@ describe("Parameter component with ItemList type", () => {
             fireEvent.click(screen.getByText("Set Multi-Selection"));
 
             await waitFor(() => {
-                expect(mockPlayerGetSelection).toHaveBeenCalled();
-                expect(mockNotificationShow).toHaveBeenCalledWith(
-                    "No items selected",
-                    "INFO",
-                );
-                expect(mockSceneGetItems).not.toHaveBeenCalled();
+                expect(OBR.player.getSelection).toHaveBeenCalled();
+                expect(OBR.notification.show).toHaveBeenCalledWith("No items selected", "INFO");
+                expect(OBR.scene.items.getItems).not.toHaveBeenCalled();
                 expect(ScriptContainerUtils.setParameterValue).not.toHaveBeenCalled();
             });
         });
         
         it("should show notification and clear value if selected items cannot be retrieved", async () => {
-            const selectedIds = ["item1-id"];
-            mockPlayerGetSelection.mockResolvedValue(selectedIds);
-            mockSceneGetItems.mockResolvedValue([]); // Items not found
+            (OBR.player.getSelection as Mock).mockResolvedValue(["item1-id"]);
+            (OBR.scene.items.getItems as Mock).mockResolvedValue([]); 
 
             render(
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: [{ id: "old-item", name:"Old Item", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} }] } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: [{ 
+                        id: "old-item", name:"Old Item", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                        createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+                    }] }}
                     idx={0}
                 />,
             );
             
-            // Initial state shows "1 item(s) selected"
             expect(screen.getByText("1 item(s) selected")).toBeInTheDocument();
 
-            fireEvent.click(screen.getByText("1 item(s) selected")); // or the chip itself
+            fireEvent.click(screen.getByText("1 item(s) selected")); 
 
             await waitFor(() => {
-                expect(mockPlayerGetSelection).toHaveBeenCalled();
-                expect(mockSceneGetItems).toHaveBeenCalledWith(selectedIds);
-                expect(mockNotificationShow).toHaveBeenCalledWith(
-                    "Could not retrieve selected items.",
-                    "WARNING",
-                );
+                expect(OBR.player.getSelection).toHaveBeenCalled();
+                expect(OBR.scene.items.getItems).toHaveBeenCalledWith(["item1-id"]);
+                expect(OBR.notification.show).toHaveBeenCalledWith("Could not retrieve selected items.", "WARNING");
                 expect(ScriptContainerUtils.setParameterValue).toHaveBeenCalledWith(
-                    mockPlayerStorageState.roomMetadata.scripts,
+                    mockPlayerStorageState.roomMetadata,
                     mockScript.id,
                     0,
                     undefined, // Value should be cleared
@@ -230,25 +326,25 @@ describe("Parameter component with ItemList type", () => {
 
     describe("Clearing Selection", () => {
         it("should call setParameterValue with undefined when delete is clicked", async () => {
-            const mockItem: Item = { id: "item1", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} };
+            const mockItem: Item = { 
+                id: "item1", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+            };
             render(
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: [mockItem] } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: [mockItem] }}
                     idx={0}
                 />,
             );
 
-            // The delete icon is usually part of the Chip component and not directly accessible by role
-            // We target the Chip's delete handler. Material UI Chip has a specific structure.
-            // We can find the cancel icon by its role if it's standard.
-            const deleteIcon = screen.getByTestId("CancelIcon"); // MUI specific, ensure this is how it's rendered or use a more generic selector
+            const deleteIcon = screen.getByTestId("CancelIcon"); 
             fireEvent.click(deleteIcon);
 
             await waitFor(() => {
                 expect(ScriptContainerUtils.setParameterValue).toHaveBeenCalledWith(
-                    mockPlayerStorageState.roomMetadata.scripts,
+                    mockPlayerStorageState.roomMetadata,
                     mockScript.id,
                     0,
                     undefined,
@@ -261,7 +357,7 @@ describe("Parameter component with ItemList type", () => {
                 <Parameter
                     editingDisabled={false}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: [] } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: [] }}
                     idx={0}
                 />,
             );
@@ -272,12 +368,15 @@ describe("Parameter component with ItemList type", () => {
     
     describe("Disabled State", () => {
         it("should disable the chip when editingDisabled is true", () => {
-            const mockItem: Item = { id: "item1", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{} };
+            const mockItem: Item = { 
+                id: "item1", name: "Item 1", layer:"CHARACTER", type: "SHAPE", visible: true, locked: false, position: {x:0,y:0}, rotation:0, scale: {x:1,y:1}, zIndex:0, metadata:{},
+                createdUserId: mockUserId, lastModified: mockDate, lastModifiedUserId: mockUserId,
+            };
             render(
                 <Parameter
                     editingDisabled={true}
                     script={mockScript}
-                    param={{ ...baseItemListParam, value: [mockItem] } as ParameterWithValue}
+                    param={{ ...baseItemListParam, type: "ItemList", value: [mockItem] }}
                     idx={0}
                 />,
             );
@@ -290,7 +389,7 @@ describe("Parameter component with ItemList type", () => {
 
             // Try to click to ensure no action happens (though true disabled state prevents event firing)
             fireEvent.click(chip!);
-            expect(OBR.player.getSelection as vi.Mock).not.toHaveBeenCalled();
+            expect(OBR.player.getSelection as Mock).not.toHaveBeenCalled(); // Check against OBR.player.getSelection
         });
     });
 });

--- a/src/action/Action.tsx
+++ b/src/action/Action.tsx
@@ -307,6 +307,40 @@ function Parameter({
                         (() => handleSetParameterValue(undefined))
                     }
                 />
+            ) : param.type === "ItemList" ? (
+                <Chip
+                    disabled={editingDisabled}
+                    label={
+                        param.value && Array.isArray(param.value) && param.value.length > 0
+                            ? `${param.value.length} item(s) selected`
+                            : "Set Multi-Selection"
+                    }
+                    onClick={async () => {
+                        const selectedIds = await OBR.player.getSelection();
+                        if (!selectedIds || selectedIds.length === 0) {
+                            OBR.notification.show("No items selected", "INFO");
+                            // Optionally, if you want to clear the value if nothing is selected:
+                            // await handleSetParameterValue(undefined); 
+                            return;
+                        }
+                        const items = await OBR.scene.items.getItems(selectedIds);
+                        if (items.length > 0) {
+                            await handleSetParameterValue(items);
+                        } else {
+                            // This case might happen if selected IDs are no longer valid
+                            OBR.notification.show(
+                                "Could not retrieve selected items.",
+                                "WARNING"
+                            );
+                            await handleSetParameterValue(undefined);
+                        }
+                    }}
+                    onDelete={
+                        param.value && Array.isArray(param.value) && param.value.length > 0
+                            ? () => handleSetParameterValue(undefined)
+                            : undefined
+                    }
+                />
             ) : (
                 <TextField
                     disabled={editingDisabled}

--- a/src/action/Action.tsx
+++ b/src/action/Action.tsx
@@ -234,7 +234,7 @@ function OverflowMenu({
     );
 }
 
-function Parameter({
+export function Parameter({
     editingDisabled,
     script,
     param,
@@ -283,12 +283,12 @@ function Parameter({
                     }
                     onClick={async () => {
                         if (param.value) {
-                            void OBR.player.select([param.value.id]);
+                            void OBR.player.select([param.value.id]); // Added void
                         } else {
                             const [selected] =
                                 (await OBR.player.getSelection()) ?? [];
                             if (!selected) {
-                                void OBR.notification.show(
+                                void OBR.notification.show( // Added void
                                     "No items selected",
                                     "ERROR",
                                 );
@@ -318,7 +318,7 @@ function Parameter({
                     onClick={async () => {
                         const selectedIds = await OBR.player.getSelection();
                         if (!selectedIds || selectedIds.length === 0) {
-                            OBR.notification.show("No items selected", "INFO");
+                            void OBR.notification.show("No items selected", "INFO"); // Added void
                             // Optionally, if you want to clear the value if nothing is selected:
                             // await handleSetParameterValue(undefined); 
                             return;
@@ -328,7 +328,7 @@ function Parameter({
                             await handleSetParameterValue(items);
                         } else {
                             // This case might happen if selected IDs are no longer valid
-                            OBR.notification.show(
+                            void OBR.notification.show( // Added void
                                 "Could not retrieve selected items.",
                                 "WARNING"
                             );

--- a/src/script/CodeoScript.ts
+++ b/src/script/CodeoScript.ts
@@ -1,6 +1,6 @@
 import { isObject } from "owlbear-utils";
 
-export const PARAMETER_TYPES = ["boolean", "string", "number", "Item"] as const;
+export const PARAMETER_TYPES = ["boolean", "string", "number", "Item", "ItemList"] as const;
 export type ParameterType = (typeof PARAMETER_TYPES)[number];
 export function isParameterType(type: unknown): type is ParameterType {
     const parameterTypes2: readonly string[] = PARAMETER_TYPES;

--- a/src/state/ScriptContainerUtils.ts
+++ b/src/state/ScriptContainerUtils.ts
@@ -44,6 +44,19 @@ function withValue<T extends ParameterWithValue>(
                 );
             }
             return { ...parameter, value };
+        case "ItemList": // Added ItemList case
+            if (!Array.isArray(value) && value !== undefined) { // value can be undefined to clear it
+                throw new Error(
+                    `Value for ItemList parameter must be an array or undefined, got ${typeof value}`,
+                );
+            }
+            // Ensure all elements are items if the array is not undefined
+            if (Array.isArray(value) && !value.every(item => typeof item === 'object' && item !== null && 'id'in item)) {
+                 throw new Error(
+                    `All elements in ItemList parameter must be Item objects`,
+                );
+            }
+            return { ...parameter, value };
     }
 }
 

--- a/src/state/StoredScript.ts
+++ b/src/state/StoredScript.ts
@@ -39,11 +39,17 @@ interface ItemParameter {
     readonly value?: Item;
 }
 
+interface ItemListParameter {
+    readonly type: "ItemList";
+    readonly value?: Item[];
+}
+
 export type ParameterWithValue =
     | BooleanParameter
     | NumberParameter
     | StringParameter
-    | ItemParameter;
+    | ItemParameter
+    | ItemListParameter;
 
 export type StoredScript = CodeoScript & {
     id: string;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,7 @@
         "noImplicitReturns": true,
         "noUncheckedIndexedAccess": true,
         "erasableSyntaxOnly": true,
-        "types": ["vitest/importMeta"]
+        "types": ["vitest/importMeta", "vitest/globals", "@testing-library/jest-dom"]
     },
     "include": ["src", "test"]
 }


### PR DESCRIPTION
This commit introduces a new script parameter type called "ItemList". This type allows you to select multiple items from the Owlbear Rodeo scene as input for your scripts, contrasting with the existing "Item" type which only allows a single item.

Key changes include:

-   **`src/script/CodeoScript.ts`**:
    -   Added "ItemList" to the `PARAMETER_TYPES` enum.
-   **`src/state/StoredScript.ts`**:
    -   Defined `ItemListParameter` interface with `value?: Item[]`.
    -   Added `ItemListParameter` to the `ParameterWithValue` union type.
-   **`src/action/Action.tsx`**:
    -   Implemented UI for "ItemList" in the `Parameter` component:
        -   Displays a chip to trigger selection.
        -   Label shows "Set Multi-Selection" or "N item(s) selected".
        -   Clicking fetches selected items from OBR and updates the parameter.
        -   Allows clearing the selection.
-   **`src/script/runScript.ts`**:
    -   Verified that existing parameter passing logic correctly handles `Item[]`
        for "ItemList" type, requiring no changes.
-   **`src/action/Action.test.tsx`**:
    -   Added new unit tests for the `Parameter` component, specifically for
        the "ItemList" type, covering rendering, selection logic (with OBR mocks),
        clearing the selection, and behavior in a disabled state.

This new parameter type enhances script capabilities by allowing them to operate on multiple scene items simultaneously.